### PR TITLE
If we call $().modal without validate $ script can fail with an Uncaught TypeError: $ is not a function

### DIFF
--- a/src/cookie-warn.js
+++ b/src/cookie-warn.js
@@ -190,7 +190,7 @@
             return;
         }
 
-        var bootstrap = window.jQuery && typeof $().modal == "function";
+        var bootstrap = window.jQuery && typeof $ == "function" && typeof $().modal == "function";
 
         var css = {
             style: [


### PR DESCRIPTION
If we call $().modal without validate $ script can fail with an Uncaught TypeError: $ is not a function.

Plus if you use $.noConflict(); probably this can fail.